### PR TITLE
Ti.UI.iPhone.ActivityIndicatorStyle is deprecated in 5.1.0

### DIFF
--- a/styles/widget.tss
+++ b/styles/widget.tss
@@ -16,16 +16,17 @@
     zIndex: 99,
 }
 
-"#loadingIndicator[platform=android]": {
-    top: '10%',
+"#loadingIndicator": {
     style: Ti.UI.ActivityIndicatorStyle.BIG,
-    zIndex: 99,
+    zIndex: 99
+}
+
+"#loadingIndicator[platform=android]": {
+    top: '10%'
 }
 
 "#loadingIndicator[platform=ios]": {
-    top: '20%',
-    style: Ti.UI.iPhone.ActivityIndicatorStyle.BIG,
-    zIndex: 99,
+    top: '20%'
 }
 
 "#loadingMessageLabel": {


### PR DESCRIPTION
Also combined common elements in a single rule and set platform-specific elements in their own rules.
